### PR TITLE
fix: Avoid admonition's format error in crowdin

### DIFF
--- a/docs/ABAC.mdx
+++ b/docs/ABAC.mdx
@@ -42,15 +42,21 @@ Simply speaking, to use ABAC, you need to do two things:
 2. Pass in the struct or class instance for the element as the argument in Casbin's ``Enforce()`` function.
 
 :::warning
+
 Currently, only request elements like ``r.sub``, ``r.obj``, ``r.act`` and so on support ABAC. You cannot use it on policy elements like ``p.sub``, because there is no way to define a struct or class in Casbin's policy.
+
 :::
 
 :::tip
+
 You can use multiple ABAC attributes in a matcher, for example: ``m = r.sub.Domain == r.obj.Domain``.
+
 :::
 
 :::tip
+
 If you need to use comma in policy which conflicts with csv's separator and we need to escape it. Casbin parses policy file through [csv library](https://pkg.go.dev/encoding/csv), you could surround statement with quotation marks. For example, `"keyMatch("bob", r.sub.Role)"` will not be split.
+
 :::
 
 ## Scaling the model for complex and large number of ABAC rules.

--- a/docs/Adapters.mdx
+++ b/docs/Adapters.mdx
@@ -202,9 +202,11 @@ Adapter | Type | Author | AutoSave | Description
 ```
 
 :::note
+
 1. If ``casbin.NewEnforcer()`` is called with an explicit or implicit adapter, the policy will be loaded automatically.
 2. You can call ``e.LoadPolicy()`` to reload the policy rules from the storage.
 3. If the adapter does not support the ``Auto-Save`` feature, The policy rules cannot be automatically saved back to the storage when you add or remove policies. You have to call ``SavePolicy()`` manually to save all policy rules.
+
 :::
 
 ## Examples
@@ -439,9 +441,11 @@ There is a feature called ``Auto-Save`` for adapters. When an adapter supports `
 When the adapter supports ``Auto-Save``, you can switch this option via ``Enforcer.EnableAutoSave()`` function. The option is enabled by default (if the adapter supports it).
 
 :::note
+
 1. The ``Auto-Save`` feature is optional. An adapter can choose to implement it or not.
 2. ``Auto-Save`` only works for a Casbin enforcer when the adapter the enforcer uses supports it.
 3. See the ``AutoSave`` column in the above adapter list to see if ``Auto-Save`` is supported by an adapter.
+
 :::
 
 Here's an example about how to use ``Auto-Save``:
@@ -491,7 +495,9 @@ RemovePolicy() | optional | Remove a policy rule from the storage
 RemoveFilteredPolicy() | optional | Remove policy rules that match the filter from the storage
 
 :::note
+
 If an adapter doesn't support ``Auto-Save``, it should provide an empty implementation for the three optional functions. Here's an example for Golang:
+
 :::
 
 ```go

--- a/docs/Dispatchers.mdx
+++ b/docs/Dispatchers.mdx
@@ -13,7 +13,9 @@ The dispatcher's method is divided into two parts. The first is the method combi
 The other part is the method defined by the dispatcher itself, including the dispatcher initialization method, and different functions provided by different algorithms, such as dynamic membership, config changes etc.
 
 :::note
+
 we hope dispatcher just ensure the consistency of Casbin enforcer at runtime. So if the policy is inconsistent when initialization, the dispatcher will not work properly. Users need to ensure that the state of all instances is consistent before using dispatcher. 
+
 :::
 
 A complete list of Casbin dispatchers is provided as below. Any 3rd-party contribution on a new dispatcher is welcomed, please inform us and we will put it in this list:)

--- a/docs/Effector.mdx
+++ b/docs/Effector.mdx
@@ -61,5 +61,7 @@ Effect, explainIndex, err = e.MergeEffects(expr, effects, matches, policyIndex, 
 The basic idea of the ```MergeEffects``` indicates that if the ```expr``` can match the results which means that the ```p_eft``` is ```allow```, then we can merge all effects at last. And if there are no deny rules are matched, then we allow.
 
 :::note
+
 If the ```expr``` can not match ```"priority(p_eft) || deny"``` and also the ```policyIndex``` is shorter than ```policyLength-1```, it will **short-circuit** some effects in the middle.
+
 :::

--- a/docs/FrontendUsage.mdx
+++ b/docs/FrontendUsage.mdx
@@ -119,6 +119,7 @@ result.then((success, failed) => {
 Correspondingly, you need to expose an interface (e.g. a RestAPI) to generate the permission object and pass it to the frontend. In your API controller, call `CasbinJsGetUserPermission` to construct the permission object. Here is an example in Beego:
 
 :::note
+
 Your endpoint server should return something like
 ```json
 {
@@ -126,6 +127,7 @@ Your endpoint server should return something like
     "data": "What you get from `CasbinJsGetPermissionForUser`"
 }
 ```
+
 :::
 
 ```Go
@@ -144,7 +146,9 @@ func (c *APIController) GetFrontendPermission() {
 ```
 
 :::note
+
 Currently, `CasbinJsGetPermissionForUser` api is only supported in Go Casbin and Node-Casbin. If you want this api to be supported in other languages, please [raise an issue](https://github.com/casbin/casbin.js/issues) or leave a comment below.
+
 :::
 
 

--- a/docs/LogError.mdx
+++ b/docs/LogError.mdx
@@ -17,8 +17,10 @@ Casbin uses the built-in ``log`` to print logs to console by default like:
 The logging is not enabled by default. You can toggle it via ``Enforcer.EnableLog()`` or the last parameter of ``NewEnforcer()``.
 
 :::note
+
 We already support logging the model, enforce request, role, policy in Golang. You can define your own log for logging Casbin.
 If you are using Python, pycasbin leverages the default Python logging mechanism. The pycasbin package makes a call to logging.getLogger() to set the logger. No special logging configuration is needed other than initializing the logger in the parent application. If no logging is intitilized within the parent application you will not see any log messages from pycasbin. 
+
 :::
 
 ### Use different logger for different enforcer
@@ -190,7 +192,9 @@ Function | Behavior on error
 [Enforce()](https://godoc.org/github.com/casbin/casbin#Enforcer.Enforce) | Return error
 
 :::note
+
 ``NewEnforcer()`` calls ``LoadModel()`` and ``LoadPolicy()`` inside. So you don't have to call the latter two calls when using ``NewEnforcer()``.
+
 :::
 
 ## Enable & disable

--- a/docs/OnlineEditor.mdx
+++ b/docs/OnlineEditor.mdx
@@ -13,5 +13,7 @@ If you use ``RBAC with pattern`` or ``RBAC with all pattern``, it specifies the 
 If you want to write the equivalent code, you need to specify the pattern matching function through the relevant api. See [RBAC with Pattern](/docs/rbac-with-pattern)
 
 :::note
+
 The editor is based on [node-casbin](https://github.com/casbin/node-casbin). Due to the synchronization delay between different language of casbin, the authentication result of the ``editor`` may be different from the authentication result of the casbin you are using. If so, please submit issues to the casbin repository you are using.
+
 :::

--- a/docs/Performance.mdx
+++ b/docs/Performance.mdx
@@ -14,7 +14,9 @@ The number of coming requests per second is too large, e.g., 10,000 request/s fo
 2. Deploy Casbin instances to a cluster (multiple machines). Use Watcher to guarantee all Casbin instances are consistent. See details at: [Watchers](/docs/watchers).
 
 :::note
+
 You can use the above methods both at the same time, e.g., deploy Casbin to a 10-machine cluster. Each machine has 5 threads simultaneously to serve Casbin enforcement requests.
+
 :::
 
 #### High Number of Policy Rules
@@ -28,5 +30,7 @@ Millions of policy rules may be required in a cloud or multi-tenant environment.
 3. Grant permissions to RBAC roles instead of users directly. Casbin's RBAC is implemented by a role inheritance tree (as a cache). So given a user like Alice, Casbin only uses O(1) time to query the RBAC tree for role-user relationship and do enforcement. If your g rules don't change often, then the RBAC tree won't need to update. See details at this dicussion: https://github.com/casbin/casbin/issues/681#issuecomment-763801583
 
 :::note
+
 You can try the above methods all at the same time.
+
 :::

--- a/docs/RBAC.mdx
+++ b/docs/RBAC.mdx
@@ -36,10 +36,12 @@ m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
 It means ``sub`` in the request should have the role ``sub`` in the policy.
 
 :::note
+
 1. Casbin only stores the user-role mapping.
 2. Casbin doesn't verify whether a user is a valid user, or role is a valid role. That should be taken care of by authentication.
 3. Do not use the same name for a user and a role inside a RBAC system, because Casbin recognizes users and roles as strings, and there's no way for Casbin to know whether you are specifying user ``alice`` or role ``alice``. You can simply solve it by using ``role_alice``.
 4. If ``A`` has role ``B``, ``B`` has role ``C``, then ``A`` has role ``C``. This transitivity is infinite for now.
+
 :::
 
 ## Role hierarchy

--- a/docs/RBACWithDomainsAPI.mdx
+++ b/docs/RBACWithDomainsAPI.mdx
@@ -368,5 +368,7 @@ res, _ := e.GetAllDomains()
 ```
 
 :::note
+
 If you are handling a domain like ```name::domain```, it may lead to unexpected behavior. In Casbin, ```::``` is a reversed keyword, just like ```for```, ```if``` in a programming language, we should never put ```::``` in a domain.
+
 :::

--- a/docs/RBACWithPattern.mdx
+++ b/docs/RBACWithPattern.mdx
@@ -27,8 +27,10 @@ import TabItem from '@theme/TabItem';
 As shown above, after you create the ``enforcer`` instance, you need to activate pattern matching via ``AddNamedMatchingFunc`` and ``AddNamedMatchingFunc`` API,  which determine how the pattern matches.
 
 :::note
+
 If you use the online editor, it specifies the pattern matching function in the lower left corner.
 ![editor-tips](/img/editor-tips.png)
+
 :::
 
 ## Use pattern matching in RBAC

--- a/docs/SyntaxForModels.mdx
+++ b/docs/SyntaxForModels.mdx
@@ -48,7 +48,9 @@ Each line in a policy is called a policy rule. Each policy rule starts with a ``
 ```
 
 :::tip
+
 The elements in a policy rule are always regarded as``string``. If you have any question about this, please see the discussion at: https://github.com/casbin/casbin/issues/113
+
 :::
 
 ## Policy effect
@@ -79,7 +81,9 @@ e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
 It means at least one matched policy rule of``allow``, and there is no matched policy rule of``deny``. So in this way, both the allow and deny authorizations are supported, and the deny overrides.
 
 :::note
+
 Although we designed the syntax of policy effect as above, the current implementations only use hard-coded policy effect, as we found there's no much need for that sort of flexibility. So for now, you must use one of the built-in policy effects instead of customizing your own one.
+
 :::
 
 The supported built-in policy effects are:
@@ -266,5 +270,7 @@ casbin-rs | Rust | https://github.com/jonathandturner/rhai
 casbin-cpp | C++ | https://github.com/ArashPartow/exprtk
 
 :::note
+
 If you encounter performance issue about Casbin, it's probably caused by the low efficiency of the expression evaluator. You can both send issue to Casbin or the expression evaluator directly for advice to speed up. See [Benchmarks](/docs/benchmark) section for details.
+
 :::	


### PR DESCRIPTION
Such this:
![image](https://user-images.githubusercontent.com/53544726/177005227-eab6ebe1-eb58-45a1-b6a1-c9960048bcf2.png)

look in crowdin:
![image](https://user-images.githubusercontent.com/53544726/177005275-a615efce-565c-4c1b-beac-7fb8b249dd36.png)

And maybe cause error (https://casbin.io/zh/docs/effector/) :
![image](https://user-images.githubusercontent.com/53544726/177005347-af240cf0-bc72-4524-817c-0ef23b7feea2.png)
