### PR TITLE
docs: add keyGet3

### DIFF
--- a/docs/Function.mdx
+++ b/docs/Function.mdx
@@ -9,29 +9,46 @@ keywords: [function, customize]
 
 ## Functions in matchers
 
-You can even specify functions in a matcher to make it more powerful. You can use the built-in functions or specify your own function. All built-in functions take such a format(except ``keyGet`` and ``keyGet2``):
+You can even specify functions in a matcher to make it more powerful. You can use the built-in functions or specify your own function.
+The built-in key-matching functions take such a format:
 
 ```C
-bool function_name(string arg1, string arg2)
+bool function_name(string url, string pattern)
 ```
 
-It returns whether ``arg1`` matches ``arg2``.
-
-``keyGet`` and ``keyGet2`` will return the string which matching the wildcard, and return ``""`` if nothing was matched.
+It returns a boolean indicating whether ``url`` matches ``pattern``.
 
 The supported built-in functions are:
 
-Function | arg1 | arg2 | Example
+Function | url | pattern | Example
 ----|------|----|----
 keyMatch | a URL path like ``/alice_data/resource1`` | a URL path or a ``*`` pattern like ``/alice_data/*`` | [keymatch_model.conf](https://github.com/casbin/casbin/blob/master/examples/keymatch_model.conf)/[keymatch_policy.csv](https://github.com/casbin/casbin/blob/master/examples/keymatch_policy.csv)
-keyGet | a URL path like ``/alice_data/resource1`` | a URL path or a ``*`` pattern like ``/alice_data/*`` | [keyget_model.conf](https://github.com/casbin/casbin/blob/master/examples/keyget_model.conf)/[keymatch_policy.csv](https://github.com/casbin/casbin/blob/master/examples/keymatch_policy.csv)
 keyMatch2 | a URL path like ``/alice_data/resource1`` | a URL path or a ``:`` pattern like ``/alice_data/:resource`` | [keymatch2_model.conf](https://github.com/casbin/casbin/blob/master/examples/keymatch2_model.conf)/[keymatch2_policy.csv](https://github.com/casbin/casbin/blob/master/examples/keymatch2_policy.csv)
-keyGet2 | a URL path like ``/alice_data/resource1`` | a URL path or ``:`` pattern like ``/alice_data/:resource`` | [keyget2_model.conf](https://github.com/casbin/casbin/blob/master/examples/keyget2_model.conf)/[keymatch2_policy.csv](https://github.com/casbin/casbin/blob/master/examples/keymatch2_policy.csv)
 keyMatch3 | a URL path like ``/alice_data/resource1`` | a URL path or a ``{}`` pattern like ``/alice_data/{resource}`` | https://github.com/casbin/casbin/blob/277c1a2b85698272f764d71a94d2595a8d425915/util/builtin_operators_test.go#L171-L196
 keyMatch4 | a URL path like ``/alice_data/123/book/123`` | a URL path or a ``{}`` pattern like ``/alice_data/{id}/book/{id}`` | https://github.com/casbin/casbin/blob/277c1a2b85698272f764d71a94d2595a8d425915/util/builtin_operators_test.go#L208-L222
 regexMatch | any string | a regular expression pattern | [keymatch_model.conf](https://github.com/casbin/casbin/blob/master/examples/keymatch_model.conf)/[keymatch_policy.csv](https://github.com/casbin/casbin/blob/master/examples/keymatch_policy.csv)
 ipMatch | an IP address like ``192.168.2.123`` | an IP address or a CIDR like ``192.168.2.0/24`` | [ipmatch_model.conf](https://github.com/casbin/casbin/blob/master/examples/ipmatch_model.conf)/[ipmatch_policy.csv](https://github.com/casbin/casbin/blob/master/examples/ipmatch_policy.csv)
 globMatch | a path-like path like ``/alice_data/resource1`` | a glob pattern like ``/alice_data/*`` | https://github.com/casbin/casbin/blob/277c1a2b85698272f764d71a94d2595a8d425915/util/builtin_operators_test.go#L426-L466
+
+
+For key-getting functions, they usually take three parameters(except `keyGet`):
+
+```C
+bool function_name(string url, string pattern, string key_name)
+```
+
+They will return the value of the key ``key_name`` if it matches the pattern, and return ``""`` if nothing is matched.
+
+For example,  ``KeyGet2("/resource1/action", "/:res/action, "res")`` will return ``"resource1"``, ``KeyGet3("/resource1_admin/action", "/{res}_admin/*", "res")`` will return ``"resource1"``.
+As for `KetGet`, which takes two parameters, ``KeyGet("/resource1/action", "/*)`` will return ``"resource1/action"``.
+
+
+| Function | url                                   | pattern                                                        | key_name                          | example                                                                                                                                                                                           |
+|----------|---------------------------------------|----------------------------------------------------------------|-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| keyGet   | a URL path like ``/proj/resource1``   | a URL path or a ``*`` pattern like ``/proj/*``                 | \                                 | [keyget_model.conf](https://github.com/casbin/casbin/blob/master/examples/keyget_model.conf)/[keymatch_policy.csv](https://github.com/casbin/casbin/blob/master/examples/keymatch_policy.csv)     |
+| keyGet2  | a URL path like ``/proj/resource1``   | a URL path or ``:`` pattern like ``/prooj/:resource``          | key name specified in the pattern | [keyget2_model.conf](https://github.com/casbin/casbin/blob/master/examples/keyget2_model.conf)/[keymatch2_policy.csv](https://github.com/casbin/casbin/blob/master/examples/keymatch2_policy.csv) |
+| keyGet3  | a URL path like ``/proj/res3_admin/`` | a URL path or ``{}`` pattern like ``/proj/{resource}_admin/*`` | key name specified in the pattern | https://github.com/casbin/casbin/blob/7bd496f94f5a2739a392d333a9aaaa10ae397673/util/builtin_operators_test.go#L209-L247                                                                           |
+
 
 See details for above functions at: https://github.com/casbin/casbin/blob/master/util/builtin_operators_test.go
 


### PR DESCRIPTION
Add docs for `keyGet3` 
PR: https://github.com/casbin/casbin/pull/1050

I also separate the table for `KeyMatch*` and `KeyGet*` to make it more clear.