### PR TITLE
fix: the hierarchy in SyntaxForModels.mdx

### DIFF
--- a/docs/SyntaxForModels.mdx
+++ b/docs/SyntaxForModels.mdx
@@ -237,7 +237,7 @@ e.enforce(enforceContext, new AbacAPIUnitTest.TestEvalRule("alice", 30), "/data1
 </Tabs>
 ```
 
-### Special Grammer
+## Special Grammer
 
 You could also use ``in``, the only operator with a text name. This operator checks the right-hand side array to see if it contains a value that is equal to the left-side value. Equality is determined by the use of the == operator, and this library doesn't check types between the values. Any two values, when cast to interface{}, and can still be checked for equality with == will act as expected. Note that you can use a parameter for the array, but it must be an ``[]interface{}``.
 
@@ -256,7 +256,7 @@ m = r.sub.Name in (r.obj.Admins)
 e.Enforce(Sub{Name: "alice"}, Obj{Name: "a book", Admins: []interface{}{"alice", "bob"}})
 ```
 
-### Expression evaluator
+## Expression evaluator
 
 The matcher evaluation in Casbin is implemented by expression evaluators in each language. Casbin integrates their powers to provide the unified PERM language. Besides all the model syntax provided here, those expression evaluators may provide extra functionality, which may be not supported by another language or implementation. Use it at your own risk.
 


### PR DESCRIPTION
Wrong hierarchy:
![image](https://user-images.githubusercontent.com/20621784/183281033-883d422f-a9a4-4f04-9bb9-d57b176c7f49.png)
