### PR TITLE
feat: Export docs to PDF

### DIFF
--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -1,0 +1,50 @@
+name: PDF build
+
+on:
+  push:
+    branches: [ "master" ]
+jobs:
+  build-pdf:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+    
+    - name: Install noto fonts
+      run: |
+        sudo apt install fonts-noto -y
+    
+    - name: Install Prince
+      run: |
+        curl https://www.princexml.com/download/prince-14.2-linux-generic-x86_64.tar.gz -O
+        tar zxf prince-14.2-linux-generic-x86_64.tar.gz
+        cd prince-14.2-linux-generic-x86_64
+        yes "" | sudo ./install.sh
+        
+    - name: Build PDF
+      run: |
+        npx docusaurus-prince-pdf --include-index -u https://casbin.io/docs/overview --output pdf/Casbin_Docs.pdf
+        npx docusaurus-prince-pdf --include-index -u https://casbin.io/zh/docs/overview --list-only
+        wget https://gist.githubusercontent.com/Selflocking/7a07d91d34ee227c93d2d8f583f981e3/raw/996a610b96e7e1f42e06ec555528f3427c2fb647/print.css
+        prince --no-warn-css --style=print.css --input-list=./pdf/casbin.io-zh-docs-overview.txt -o pdf/Casbin_Docs_zh.pdf
+    
+    - name: Delete Release
+      uses: dev-drprasad/delete-tag-and-release@v0.2.0
+      with:
+        delete_release: true # default: false
+        tag_name: pdf # tag name to delete
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Upload Release
+      uses: softprops/action-gh-release@v1
+      with:
+        name: Casbin Docs
+        tag_name: pdf
+        files: pdf/*.pdf
+        body: auto-generated Casbin Docs in PDF format


### PR DESCRIPTION
close: #68 
Preview: https://github.com/Selflocking/casbin-website-v2/releases/tag/pdf

ci use [docusaurus-prince-pdf](https://github.com/signcl/docusaurus-prince-pdf) to generate pdf. When successfully built, ci will remove the release tagged pdf (if exists), and create a new release tagged pdf