### PR TITLE
docs: add docs for GetNamedRoleManager & SetNamedRoleManager

### DIFF
--- a/docs/RoleManagerApi.mdx
+++ b/docs/RoleManagerApi.mdx
@@ -14,7 +14,7 @@ Adding matching function to rolemanager allows using wildcards in role name and 
 
 ### `AddNamedMatchingFunc()`
 
-AddNamedMatchingFunc add MatchingFunc by ptype RoleManager.
+AddNamedMatchingFunc add MatchingFunc by ptype to RoleManager.
 MatchingFunc will work when operating role matching.
 
 ```mdx-code-block
@@ -134,6 +134,111 @@ For example:
 
 ```python
     rm = e.get_role_manager()
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
+
+### `GetNamedRoleManager()`
+
+GetNamedRoleManager gets the role manager by named ptype.
+
+For example:
+
+```mdx-code-block
+<Tabs groupId="langs">
+<TabItem value="Go" label="Go" default>
+```
+
+```go
+    rm := e.GetNamedRoleManager("g2")
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="Node.js" label="Node.js">
+```
+
+```typescript
+    const rm = await e.getNamedRoleManager("g2");
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="Python" label="Python">
+```
+
+```python
+    rm = e.get_named_role_manager("g2")
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
+
+### `SetRoleManager()`
+
+SetRoleManager sets the current role manager for `g`.
+
+For example:
+
+```mdx-code-block
+<Tabs groupId="langs">
+<TabItem value="Go" label="Go" default>
+```
+
+```go
+    e.SetRoleManager(rm)
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="Node.js" label="Node.js">
+```
+
+```typescript
+    e.setRoleManager(rm);
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="Python" label="Python">
+```
+
+```python
+    rm = e.set_role_manager(rm)
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
+
+### `SetNamedRoleManager()`
+
+SetNamedRoleManager sets the role manager by named ptype.
+
+For example:
+
+```mdx-code-block
+<Tabs groupId="langs">
+<TabItem value="Go" label="Go" default>
+```
+
+```go
+    rm := e.SetNamedRoleManager("g2", rm)
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="Python" label="Python">
+```
+
+```python
+    rm = e.set_role_manager("g2", rm)
 ```
 
 ```mdx-code-block


### PR DESCRIPTION
add docs for PR casbin/casbin#1078

The docs for the set functions may be a bit vague, since where did `rm` come from is not explained.

It seems that `setNamedRoleManager` is not implemented in node-casbin.