### PR TITLE
fix : Navbar height altered to accommodate all links and avoid unnatural overlap

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -67,7 +67,7 @@ module.exports = {
         },
         {
           href: "https://casdoor.com",
-          label: "Hosting Plan (SaaS)",
+          label: "Hosting Plan(SaaS)",
           position: "left",
         },
         {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -34,6 +34,7 @@
   --ifm-font-family-monospace: "Fira Code VF", SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   --ifm-code-font-size: 95%; /* code block font size */
   --site-primary-hue-saturation: 210 68%; /* announcementBar */
+  --ifm-navbar-height: 5.5rem; /* overiridng Navbar Height to accomodate links */
 
   /* https://docusaurus.io/docs/styling-layout#styling-your-site-with-infima */
   --ifm-color-primary: #4c00ff;


### PR DESCRIPTION
**Previous State of website (Landing Page):**

<img width="1244" alt="Beforehome" src="https://user-images.githubusercontent.com/122589409/213902886-642d9799-d229-492b-b99c-2b4422eebcb3.png">


**After changes executed (Landing Page):**

<img width="1280" alt="Afterhome" src="https://user-images.githubusercontent.com/122589409/213902908-ebe4cb13-a4f3-4ebc-9488-e6f41a459e0b.png">


**Previous State of website (on scrolling):**

<img width="1244" alt="Beforescroll" src="https://user-images.githubusercontent.com/122589409/213902924-c1eea893-4419-417d-9615-2f081807d056.png">

**After changes executed (on scrolling):**

<img width="1280" alt="After scroll" src="https://user-images.githubusercontent.com/122589409/213902959-1222dabc-d240-4d8e-a5ea-9adb798f2489.png">

