### PR TITLE
feat: GetImplicitUsersForPermission, GetAllowedObjectConditions

### DIFF
--- a/docs/RBACAPI.mdx
+++ b/docs/RBACAPI.mdx
@@ -1546,3 +1546,78 @@ resources, err := e.GetImplicitResourcesForUser("alice")
 </TabItem>
 </Tabs>
 ```
+
+
+
+### `GetImplicitUsersForPermission`
+
+GetImplicitUsersForPermission gets implicit users for a permission.
+
+For example:
+```csv
+p, admin, data1, read
+p, bob, data1, read
+g, alice, admin
+```
+
+GetImplicitUsersForPermission("data1", "read") will return: `["alice", "bob"]`.
+
+Note: only users will be returned, roles (2nd arg in "g") will be excluded.
+
+
+```mdx-code-block
+<Tabs groupId="langs">
+<TabItem value="Go" label="Go" default>
+```
+
+```go
+users, err := e.GetImplicitUsersForPermission("data1", "read")
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
+
+### `GetAllowedObjectConditions`
+
+GetAllowedObjectConditions returns a string array of object conditions that the user can access.
+
+For example:
+
+```csv
+p, alice, r.obj.price < 25, read
+p, admin, r.obj.category_id = 2, read
+p, bob, r.obj.author = bob, write
+
+g, alice, admin
+```
+
+e.GetAllowedObjectConditions("alice", "read", "r.obj.") will return ` ["price < 25", "category_id = 2"], nil`
+`
+`
+
+Note:
+
+0. prefix: You can customize the prefix of the object conditions, and "r.obj." is commonly used as a prefix.
+After removing the prefix, the remaining part is the condition of the object.
+If there is an obj policy that does not meet the prefix requirement, an `errors.ERR_OBJ_CONDITION` will be returned.
+
+1. If the 'objectConditions' array is empty, return `errors.ERR_EMPTY_CONDITION`
+This error is returned because some data adapters' ORM return full table data by default
+when they receive an empty condition, which tends to behave contrary to expectations.(e.g. GORM)
+If you are using an adapter that does not behave like this, you can choose to ignore this error.
+
+```mdx-code-block
+<Tabs groupId="langs">
+<TabItem value="Go" label="Go" default>
+```
+
+```go
+conditions, err := e.GetAllowedObjectConditions("alice", "read", "r.obj.")
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```

--- a/docs/RBACAPI.mdx
+++ b/docs/RBACAPI.mdx
@@ -1549,7 +1549,7 @@ resources, err := e.GetImplicitResourcesForUser("alice")
 
 
 
-### `GetImplicitUsersForPermission`
+### `GetImplicitUsersForPermission()`
 
 GetImplicitUsersForPermission gets implicit users for a permission.
 
@@ -1579,7 +1579,7 @@ users, err := e.GetImplicitUsersForPermission("data1", "read")
 </Tabs>
 ```
 
-### `GetAllowedObjectConditions`
+### `GetAllowedObjectConditions()`
 
 GetAllowedObjectConditions returns a string array of object conditions that the user can access.
 


### PR DESCRIPTION
fix: https://github.com/casbin/casbin/issues/1233
add `GetImplicitUsersForPermission`
doc about: https://github.com/casbin/casbin/pull/1230 (already merged)
add `GetAllowedObjectConditions`