### PR TITLE
fix: ignore a link in links check

### DIFF
--- a/.github/workflows/docs.links.check.config.json
+++ b/.github/workflows/docs.links.check.config.json
@@ -8,6 +8,9 @@
         },
         {
             "pattern": "^https://www.thinkphp.cn/"
+        },
+        {
+            "pattern": "^http://www.jos.org.cn/1000-9825/5624.htm"
         }
     ]
 }


### PR DESCRIPTION
This link is accessible normally, probably its provider is blocking traffic from github action, so we can skip checking this link.