### PR TITLE
ci: update a ignore pattern

### DIFF
--- a/.github/workflows/docs.links.check.config.json
+++ b/.github/workflows/docs.links.check.config.json
@@ -1,7 +1,7 @@
 {
     "ignorePatterns": [
         {
-            "pattern": "^[^h]"
+            "pattern": "^(?!https?:\/\/)"
         },
         {
             "pattern": "^https://codeigniter.com/"


### PR DESCRIPTION
resolved: https://github.com/casnode/casnode-website/pull/93#discussion_r1257318253

Make regular expressions more readable and avoid matching other strings starting with 'h', such as "help".