### PR TITLE
fix: 404 issue

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,7 +12,6 @@ module.exports = {
   favicon: "img/favicon.png",
   organizationName: "casbin", // Usually your GitHub org/user name.
   projectName: "casbin.io", // Usually your repo name.
-  trailingSlash: false,
   themeConfig: {
     metadata: [{name: "Casbin", content: "An authorization library that supports access control models like ACL, RBAC, ABAC for Golang, Java, C/C++, Node.js, Javascript, PHP, Laravel, Python, .NET (C#), Delphi, Rust, Ruby, Swift (Objective-C), Lua (OpenResty), Dart (Flutter) and Elixir"}],
     algolia: {


### PR DESCRIPTION
see: https://github.com/slorber/trailing-slash-guide

get 404 when GET `https://casbin.org/editor/`

![image](https://github.com/casbin/casbin-website-v2/assets/53544726/007a6f00-87ee-404f-a734-fd2a28a7eee4)
