### PR TITLE
ci: use fixed version of markdownlint-cli

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,6 +1,7 @@
 name: Markdown Lint
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - 'docs/**'
@@ -14,12 +15,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '18.x'
 
       - name: Install markdownlint
-        run: npm install -g markdownlint-cli
+        run: npm install -g markdownlint-cli@0.35.0
 
       - name: Run markdownlint
         run: markdownlint 'docs/**/*.{md,mdx}' --config .markdownlint.jsonc


### PR DESCRIPTION
fix: https://github.com/casbin/casbin-website-v2/actions/runs/7006528641/job/19059450937?pr=216