### PR TITLE
docs: add GetAllRolesByDomain() API to docs

### DIFF
--- a/docs/RBACWithDomainsAPI.mdx
+++ b/docs/RBACWithDomainsAPI.mdx
@@ -368,6 +368,32 @@ If you are handling a domain like ```name::domain```, it may lead to unexpected 
 
 :::
 
+### `GetAllRolesByDomain()`
+
+GetAllRolesByDomain would get all roles associated with the domain.
+
+For example:
+
+```mdx-code-block
+<Tabs groupId="langs">
+<TabItem value="Go" label="Go" default>
+```
+
+```go
+res := e.GetAllRolesByDomain("domain1")
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
+
+:::note
+
+This method does not apply to domains that have an inheritance relationship, also known as implicit roles.
+
+:::
+
 ### `GetImplicitUsersForResourceByDomain()`
 
 GetImplicitUsersForResourceByDomain return implicit user based on resource and domain.


### PR DESCRIPTION
Add missing method `GetAllRolesByDomain` to docs (included in package but not in docs, see https://github.com/casbin/casbin/blob/master/rbac_api_with_domains.go)