### PR TITLE
docs: remove buttress service

### DIFF
--- a/docs/Service.mdx
+++ b/docs/Service.mdx
@@ -12,5 +12,4 @@ authors: [hsluoyz]
 |--------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
 | [Casbin Server](https://github.com/casbin/casbin-server)     | The official "Casbin as a Service" solution based on [gRPC](https://grpc.io/). Both Management API and RBAC API are provided. |
 | [middleware-acl](https://github.com/luk4z7/middleware-acl)   | RESTful access control middleware based on Casbin.                                                                              |
-| [Buttress](https://github.com/merajsahebdar/buttress-server) | The Access Control as a Service solution based on Casbin.                                                                       |
 | [auth-server](https://github.com/ZettaAI/auth-server)        | Auth Server for proofreading services.                                                                                          |


### PR DESCRIPTION
I would like to start by expressing my admiration for Casbin. The dedication and hard work that have gone into it are truly commendable.

With that respect in mind, I am reaching out to request the removal of the link to my now-discontinued project, [Buttress](https://github.com/merajsahebdar/buttress-server). While it was an honor to be part of the Casbin ecosystem, the project is no longer active or maintained, and its presence might mislead users to outdated or unsupported resources.

To maintain the integrity and relevance of the Casbin ecosystem, I believe removing this link would be beneficial. I have made the necessary changes in this pull request, ensuring that only the specific link is affected and all other aspects of the project remain intact. I am open to any suggestions or discussions regarding this change.

Thank you for your understanding, and for your continued commitment to excellence with Casbin. I appreciate your prompt attention to this matter and look forward to any feedback.