### PR TITLE
fix: build-and-deploy action error by remove ru translation temporary

### DIFF
--- a/docs/Middlewares.mdx
+++ b/docs/Middlewares.mdx
@@ -12,7 +12,8 @@ authors: [hsluoyz]
 <Tabs groupId="langs">
 <TabItem value="Go" label="Go" default>
 
-import {MiddlewareDotNETData} from "@site/src/tableData/MiddlewareData/MiddlewareDotNETData"; import {
+import {MiddlewareDotNETData} from "@site/src/tableData/MiddlewareData/MiddlewareDotNETData";
+import {
   MiddlewareGoData
 } from "@site/src/tableData/MiddlewareData/MiddlewareGoData";
 import {MiddlewareJavaData} from "@site/src/tableData/MiddlewareData/MiddlewareJavaData";

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -352,6 +352,6 @@ var _hmt = _hmt || [];
   ],
   i18n: {
     defaultLocale: "en",
-    locales: ["en", "zh", "ko", "ru", "fr", "de", "ja"],
+    locales: ["en", "zh", "ko", "fr", "de", "ja"],
   },
 };


### PR DESCRIPTION
fix: build-and-deploy action error by remove ru translation temporary