### PR TITLE
docs: fix wording in "How it works" page

### DIFF
--- a/docs/HowItWorks.mdx
+++ b/docs/HowItWorks.mdx
@@ -99,6 +99,6 @@ Furthermore, if you are using ABAC, you can try the 'in' operator as shown in th
 m = r.obj == p.obj && r.act == p.act || r.obj in ('data2', 'data3')
 ```
 
-But you **SHOULD** make sure that the length of the array is **MORE** than **1**, otherwise it will cause a panic.
+But you **MUST** make sure that the length of the array is **MORE** than **1**, otherwise it will cause a panic.
 
 For more operators, you may take a look at [govaluate](https://github.com/Knetic/govaluate).


### PR DESCRIPTION
I think it's better to replace 'SHOULD' by 'MUST'.

In the context of guidelines, recommendations, or requirements, "must" and "should" have distinct levels of obligation or expectation:

- **Must** indicates a requirement, obligation, or something that is mandatory. It's used when there's no room for discretion or deviation from the directive. In legal or formal contexts, "must" signifies an absolute requirement.

- **Should** suggests a recommendation or advice that is strongly encouraged but not mandatory. It implies that there are reasons or benefits to follow the guidance, but it's not an absolute requirement. There may be acceptable reasons or circumstances to deviate from a "should" directive.

So, when you see "must," think of it as a non-negotiable rule, whereas "should" is more of a strong suggestion that allows for some exceptions under certain conditions.