### PR TITLE
fix: fix dark mode not updated bug

### DIFF
--- a/src/pages/editor.js
+++ b/src/pages/editor.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useEffect, useState} from "react";
 import Layout from "@theme/Layout";
 import Giscus from "@giscus/react";
 import {useColorMode} from "@docusaurus/theme-common";
@@ -8,10 +8,17 @@ function EditorContent() {
   const {colorMode} = useColorMode();
   const {i18n} = useDocusaurusContext();
   const currentLanguage = i18n.currentLocale;
+  const [iframeKey, setIframeKey] = useState(0);
+
+  useEffect(() => {
+    setIframeKey(prevKey => prevKey + 1);
+  }, [colorMode]);
+
   return (
     <>
       <div className="editor-container">
         <iframe
+          key={iframeKey}
           src={`https://editor.casbin.org/?theme=${colorMode}&lang=${currentLanguage}`}
           className="editor-iframe"
           title="Casbin-editor"

--- a/src/pages/editor.js
+++ b/src/pages/editor.js
@@ -8,18 +8,17 @@ function EditorContent() {
   const {colorMode} = useColorMode();
   const {i18n} = useDocusaurusContext();
   const currentLanguage = i18n.currentLocale;
-  const [iframeKey, setIframeKey] = useState(0);
+  const [editorUrl, setEditorUrl] = useState("");
 
   useEffect(() => {
-    setIframeKey(prevKey => prevKey + 1);
-  }, [colorMode]);
+    setEditorUrl(`https://editor.casbin.org/?theme=${colorMode}&lang=${currentLanguage}`);
+  }, [colorMode, currentLanguage]);
 
   return (
     <>
       <div className="editor-container">
         <iframe
-          key={iframeKey}
-          src={`https://editor.casbin.org/?theme=${colorMode}&lang=${currentLanguage}`}
+          src={editorUrl}
           className="editor-iframe"
           title="Casbin-editor"
         />


### PR DESCRIPTION
When refreshing the page, the React component will re-render. However, the useColorMode hook may have retrieved the color mode before the iframe's URL updates. This can lead to the iframe using an old or default theme.