### PR TITLE
fix: update copyright year and owner in contributing guidelines

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025 Casbin Organization
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This pull request updates the copyright information in the contributing guidelines file. The placeholder for the year and owner has been replaced with the correct year (2025) and the Casbin Organization as the copyright owner.

**Changes made:**
- Updated the copyright line from:
  ```
  Copyright [yyyy] [name of copyright owner]
  ```
  to:
  ```
  Copyright 2025 Casbin Organization
  ```

This update ensures that the contributing guidelines reflect the current year and the correct copyright owner.