### PR TITLE
fix: modify format of CommandLineTools.mdx

### DIFF
--- a/docs/CommandLineTools.mdx
+++ b/docs/CommandLineTools.mdx
@@ -85,13 +85,13 @@ cargo install casbin-rust-cli
     ./casbin enforce -m "examples/rbac_model.conf" -p "examples/rbac_policy.csv" "alice" "data1" "read"
     ```
 
-    > {"allow":true,"explain":null}
+    > `{"allow":true,"explain":null}`
 
     ```shell
     ./casbin enforce -m "[request_definition]\nr = sub, obj, act\n[policy_definition]\np = sub, obj, act\n[role_definition]\ng = _, _\n[policy_effect]\ne = some(where (p.eft == allow))\n[matchers]\nm = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act" -p "p, alice, data1, read\np, bob, data2, write\np, data2_admin, data2, read\np, data2_admin, data2, write\ng, alice, data2_admin" "alice" "data1" "read"
     ```
 
-    > {"allow":true,"explain":null}
+    > `{"allow":true,"explain":null}`
 
 - Check whether Alice has write permission for data2. If so, display the effective policy.
 
@@ -99,7 +99,7 @@ cargo install casbin-rust-cli
     ./casbin enforceEx -m "examples/rbac_model.conf" -p "examples/rbac_policy.csv" "alice" "data2" "write"
     ```
 
-    > {"allow":true,"explain":["data2_admin","data2","write"]}
+    > `{"allow":true,"explain":["data2_admin","data2","write"]}`
 
 - Add a policy to the policy file ( casbin-java-cli only )
 
@@ -107,7 +107,7 @@ cargo install casbin-rust-cli
     ./casbin addPolicy -m "examples/rbac_model.conf" -p "examples/rbac_policy.csv" "alice" "data2" "write"
     ```
 
-    > {"allow":true,"explain":null}
+    > `{"allow":true,"explain":null}`
 
 - Delete a policy from the policy file ( casbin-java-cli only )
 
@@ -115,4 +115,4 @@ cargo install casbin-rust-cli
     ./casbin removePolicy -m "examples/rbac_model.conf" -p "examples/rbac_policy.csv" "alice" "data2" "write"
     ```
 
-    > {"allow":true,"explain":null}
+    > `{"allow":true,"explain":null}`


### PR DESCRIPTION
fix: modify format of CommandLineTools.mdx
❌ File 'docs/CommandLineTools.mdx'
❌ Wrong parameters: 
<key: storageId, code: fileInvalid, message: MDX file is invalid in line 88, column 15. Message: Could not parse expression with acorn: Unexpected content after expression>