### PR TITLE
feat: add Pgx Adapter to the ecosystem list

### DIFF
--- a/src/tableData/AdapterData/AdapterGoData.js
+++ b/src/tableData/AdapterData/AdapterGoData.js
@@ -143,7 +143,7 @@ export const AdapterGoData = [
     description:
       "MySQL, SQLite, PostgreSQL, SQL Server are supported by [Bun ORM](https://bun.uptrace.dev/guide/drivers.html)",
     image: null,
-  },    
+  },
   {
     title:
       "[Filtered PostgreSQL Adapter](https://github.com/casbin/casbin-pg-adapter)",
@@ -162,6 +162,14 @@ export const AdapterGoData = [
     description:
       "PostgreSQL is supported by [pgx](https://github.com/jackc/pgx)",
     image: "/img/ecosystem/postgreSQL.png",
+  },
+  {
+    "title": "[Pgx Adapter](https://github.com/gtoxlili/pgx-adapter)",
+    "type": "SQL",
+    "author": "[@gtoxlili](https://github.com/gtoxlili)",
+    "autoSave": "✅",
+    "description": "PostgreSQL is supported by [pgx](https://github.com/jackc/pgx), supports customizable column count",
+    "image": "/img/ecosystem/postgreSQL.png",
   },
   {
     title:


### PR DESCRIPTION
I've created a new PostgreSQL adapter using the pgx driver that features customizable column count capability. This allows users to define policy tables with more or fewer columns than the standard six fields, which can be useful in various production scenarios.

Regarding implementation, I noticed the `UpdateFilteredPolicies` interface isn't clearly documented. Could someone please explain how this method should behave, what it's expected to return, and some use cases? I haven't implemented it yet as I'm not certain about its intended functionality.