### PR TITLE
feat: set chat popup to update every 24 hours

### DIFF
--- a/static/js/casibase.js
+++ b/static/js/casibase.js
@@ -1,33 +1,7 @@
-(function(w, d, s, c, i) {
-  // Set the close timestamp, fallback to cookie if localStorage is unavailable
-  function setPopupClosedTime(ts) {
-    try {
-      localStorage.setItem("casibaseChatClosedTime", ts);
-    } catch (e) {
-      document.cookie = "casibaseChatClosedTime=" + ts + ";max-age=86400;path=/";
-    }
-  }
-  // Get the last close timestamp, fallback to cookie if localStorage is unavailable
-  function getPopupClosedTime() {
-    try {
-      const v = localStorage.getItem("casibaseChatClosedTime");
-      return v !== null ? v : "0";
-    } catch (e) {
-      const match = document.cookie.match(/(?:^|; )casibaseChatClosedTime=(\d+)/);
-      return match ? match[1] : "0";
-    }
-  }
-
-  // By default, do not show the chat window
-  let chatClosed = false;
-  let lastClosed = 0;
-  // Get the last closed timestamp, support both localStorage and cookie
-  lastClosed = parseInt(getPopupClosedTime(), 10) || 0;
-  const now = Date.now();
-  // If the last close time is within 24 hours, do not auto popup chat window
-  if (now - lastClosed < 86400000) {
-    chatClosed = true;
-  }
+(function(w, d, s, c) {
+  const key = "casibaseChatClosedTime";
+  const lastClosed = parseInt(localStorage.getItem(key) || "0", 10) || 0;
+  const chatClosed = Date.now() - lastClosed < 86400000;
 
   const j = d.createElement(s);
   j.async = false;
@@ -36,37 +10,13 @@
     w[c]("init", {
       endpoint: "https://ai.casbin.com",
       themeColor: "rgb(64,59,121)",
-      // Only popup once in 24 hours, if chatClosed is true do not auto popup
       popupTime: chatClosed ? -1 : 5,
       onClose: function() {
-        // Record current timestamp when closed, do not popup again within 24 hours
-        setPopupClosedTime(Date.now().toString());
+        localStorage.setItem(key, Date.now().toString());
       },
     });
-
-    // For remote scripts that do not support onClose, listen to DOM changes
-    const observer = new MutationObserver(function(mutations) {
-      mutations.forEach(function(mutation) {
-        if (
-          mutation.type === "attributes" &&
-          mutation.target.classList.contains("chat-container")
-        ) {
-          // Record timestamp when chat window is closed
-          if (!mutation.target.classList.contains("open") && mutation.oldValue && mutation.oldValue.includes("open")) {
-            setPopupClosedTime(Date.now().toString());
-          }
-        }
-      });
-    });
-    setTimeout(function() {
-      const chat = document.querySelector(".chat-container");
-      if (chat) {
-        observer.observe(chat, {attributes: true, attributeOldValue: true, attributeFilter: ["class"]});
-      }
-    }, 2000);
   };
-  const f = d.getElementsByTagName(s)[0];
-  f.parentNode.insertBefore(j, f);
+  d.getElementsByTagName(s)[0].parentNode.insertBefore(j, d.getElementsByTagName(s)[0]);
   w[c] = w[c] || function() {
     (w[c].q = w[c].q || []).push(arguments);
   };

--- a/static/js/casibase.js
+++ b/static/js/casibase.js
@@ -1,5 +1,5 @@
 (function(w, d, s, c, i) {
-  // Read/write close timestamp, fallback to cookie if localStorage is unavailable
+  // Set the close timestamp, fallback to cookie if localStorage is unavailable
   function setPopupClosedTime(ts) {
     try {
       localStorage.setItem("casibaseChatClosedTime", ts);
@@ -10,10 +10,11 @@
   // Get the last close timestamp, fallback to cookie if localStorage is unavailable
   function getPopupClosedTime() {
     try {
-      return localStorage.getItem("casibaseChatClosedTime");
+      const v = localStorage.getItem("casibaseChatClosedTime");
+      return v !== null ? v : "0";
     } catch (e) {
       const match = document.cookie.match(/(?:^|; )casibaseChatClosedTime=(\d+)/);
-      return match ? match[1] : null;
+      return match ? match[1] : "0";
     }
   }
 
@@ -23,7 +24,7 @@
   // Get the last closed timestamp, support both localStorage and cookie
   lastClosed = parseInt(getPopupClosedTime(), 10) || 0;
   const now = Date.now();
-  // If the last close time is within 24h, do not auto popup chat window
+  // If the last close time is within 24 hours, do not auto popup chat window
   if (now - lastClosed < 86400000) {
     chatClosed = true;
   }
@@ -35,10 +36,10 @@
     w[c]("init", {
       endpoint: "https://ai.casbin.com",
       themeColor: "rgb(64,59,121)",
-      // Only popup once in 24h, if chatClosed is true do not auto popup
+      // Only popup once in 24 hours, if chatClosed is true do not auto popup
       popupTime: chatClosed ? -1 : 5,
       onClose: function() {
-        // Record current timestamp when closed, do not popup again within 24h
+        // Record current timestamp when closed, do not popup again within 24 hours
         setPopupClosedTime(Date.now().toString());
       },
     });

--- a/static/js/casibase.js
+++ b/static/js/casibase.js
@@ -1,5 +1,5 @@
 (function(w, d, s, c, i) {
-  // 读写关闭时间戳，localStorage 不可用时用 cookie 兜底
+  // Read/write close timestamp, fallback to cookie if localStorage is unavailable
   function setPopupClosedTime(ts) {
     try {
       localStorage.setItem("casibaseChatClosedTime", ts);
@@ -7,23 +7,23 @@
       document.cookie = "casibaseChatClosedTime=" + ts + ";max-age=86400;path=/";
     }
   }
-  // 获取上次关闭的时间戳，localStorage不可用时用 cookie 兜底
+  // Get the last close timestamp, fallback to cookie if localStorage is unavailable
   function getPopupClosedTime() {
     try {
       return localStorage.getItem("casibaseChatClosedTime");
     } catch (e) {
-      let match = document.cookie.match(/(?:^|; )casibaseChatClosedTime=(\d+)/);
+      const match = document.cookie.match(/(?:^|; )casibaseChatClosedTime=(\d+)/);
       return match ? match[1] : null;
     }
   }
 
-  // 默认不弹出聊天窗口
+  // By default, do not show the chat window
   let chatClosed = false;
   let lastClosed = 0;
-  // 获取上次关闭弹窗的时间戳，支持 localStorage 和 cookie
+  // Get the last closed timestamp, support both localStorage and cookie
   lastClosed = parseInt(getPopupClosedTime(), 10) || 0;
   const now = Date.now();
-  // 如果上次关闭时间在24h内，则不自动弹出聊天窗口
+  // If the last close time is within 24h, do not auto popup chat window
   if (now - lastClosed < 86400000) {
     chatClosed = true;
   }
@@ -35,22 +35,22 @@
     w[c]("init", {
       endpoint: "https://ai.casbin.com",
       themeColor: "rgb(64,59,121)",
-      // 24小时内只弹一次，chatClosed为true时不自动弹出
+      // Only popup once in 24h, if chatClosed is true do not auto popup
       popupTime: chatClosed ? -1 : 5,
       onClose: function() {
-        // 关闭时记录当前时间戳，24小时内不再弹出
+        // Record current timestamp when closed, do not popup again within 24h
         setPopupClosedTime(Date.now().toString());
       },
     });
 
-    // 兼容远程脚本不支持 onClose 的情况，监听 DOM 变化
+    // For remote scripts that do not support onClose, listen to DOM changes
     const observer = new MutationObserver(function(mutations) {
       mutations.forEach(function(mutation) {
         if (
           mutation.type === "attributes" &&
           mutation.target.classList.contains("chat-container")
         ) {
-          // 关闭弹窗时记录时间戳
+          // Record timestamp when chat window is closed
           if (!mutation.target.classList.contains("open") && mutation.oldValue && mutation.oldValue.includes("open")) {
             setPopupClosedTime(Date.now().toString());
           }

--- a/static/js/casibase.js
+++ b/static/js/casibase.js
@@ -1,4 +1,33 @@
 (function(w, d, s, c, i) {
+  // 读写关闭时间戳，localStorage 不可用时用 cookie 兜底
+  function setPopupClosedTime(ts) {
+    try {
+      localStorage.setItem("casibaseChatClosedTime", ts);
+    } catch (e) {
+      document.cookie = "casibaseChatClosedTime=" + ts + ";max-age=86400;path=/";
+    }
+  }
+  // 获取上次关闭的时间戳，localStorage不可用时用 cookie 兜底
+  function getPopupClosedTime() {
+    try {
+      return localStorage.getItem("casibaseChatClosedTime");
+    } catch (e) {
+      let match = document.cookie.match(/(?:^|; )casibaseChatClosedTime=(\d+)/);
+      return match ? match[1] : null;
+    }
+  }
+
+  // 默认不弹出聊天窗口
+  let chatClosed = false;
+  let lastClosed = 0;
+  // 获取上次关闭弹窗的时间戳，支持 localStorage 和 cookie
+  lastClosed = parseInt(getPopupClosedTime(), 10) || 0;
+  const now = Date.now();
+  // 如果上次关闭时间在24h内，则不自动弹出聊天窗口
+  if (now - lastClosed < 86400000) {
+    chatClosed = true;
+  }
+
   const j = d.createElement(s);
   j.async = false;
   j.src = "https://tcdn.casibase.org/casibase.js";
@@ -6,8 +35,34 @@
     w[c]("init", {
       endpoint: "https://ai.casbin.com",
       themeColor: "rgb(64,59,121)",
-      popupTime: 5,
+      // 24小时内只弹一次，chatClosed为true时不自动弹出
+      popupTime: chatClosed ? -1 : 5,
+      onClose: function() {
+        // 关闭时记录当前时间戳，24小时内不再弹出
+        setPopupClosedTime(Date.now().toString());
+      },
     });
+
+    // 兼容远程脚本不支持 onClose 的情况，监听 DOM 变化
+    const observer = new MutationObserver(function(mutations) {
+      mutations.forEach(function(mutation) {
+        if (
+          mutation.type === "attributes" &&
+          mutation.target.classList.contains("chat-container")
+        ) {
+          // 关闭弹窗时记录时间戳
+          if (!mutation.target.classList.contains("open") && mutation.oldValue && mutation.oldValue.includes("open")) {
+            setPopupClosedTime(Date.now().toString());
+          }
+        }
+      });
+    });
+    setTimeout(function() {
+      const chat = document.querySelector(".chat-container");
+      if (chat) {
+        observer.observe(chat, {attributes: true, attributeOldValue: true, attributeFilter: ["class"]});
+      }
+    }, 2000);
   };
   const f = d.getElementsByTagName(s)[0];
   f.parentNode.insertBefore(j, f);


### PR DESCRIPTION
**Enhance Chat Popup 24-Hour State Update Mechanism and Storage Fallback PR**

**1、24-Hour Chat Popup State Update**
Now, when the popup is closed, the close timestamp is recorded.
On each page load, the code checks whether 24 hours (86400000 ms) have passed since the last close. If not, the popup will not automatically appear; if more than 24 hours have passed, it will appear again. This ensures the popup only shows once every 24 hours.

**2、Fallback to Cookie for AI Chat Popup Close State**
Previously, only localStorage was used to record the popup close timestamp.
To handle browsers or privacy modes where localStorage may be unavailable, a cookie fallback mechanism is added.
If localStorage is unavailable, cookies are automatically used to store the close timestamp.
This maximizes consistency of the popup experience across different environments.

**Effect**
When localStorage is available, behavior is unchanged. When unavailable, cookies are used as a fallback.
The "only show once every 24 hours" feature is reliably achieved, improving user experience, compatibility, and robustness.