### PR TITLE
docs: casbin-traefik-forward-auth renamed to casbin-forward-auth

### DIFF
--- a/src/tableData/MiddlewareData/MiddlewareGoData.js
+++ b/src/tableData/MiddlewareData/MiddlewareGoData.js
@@ -20,7 +20,7 @@ export const MiddlewareGoData = [
   {
     title: "[Traefik](https://github.com/traefik/traefik)",
     description:
-      "The cloud native application proxy, via plugin: [traefik-auth-plugin](https://github.com/Knight-7/auth-plugin) or [casbin-traefik-forward-auth](https://github.com/grepplabs/casbin-forward-auth)",
+      "The cloud native application proxy, via plugin: [casbin-forward-auth](https://github.com/grepplabs/casbin-forward-auth) or [traefik-auth-plugin](https://github.com/Knight-7/auth-plugin)",
     image: "/img/ecosystem/traefik.png",
   },
   {


### PR DESCRIPTION
`casbin-traefik-forward-auth` repository was renamed to `casbin-forward-auth` to reflect upcoming support for additional proxies