### PR TITLE
feat: add a news bar in main hero section

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -318,4 +318,8 @@ var _hmt = _hmt || [];
     defaultLocale: "en",
     locales: ["en", "zh", "ko", "ru", "fr", "de", "ja", "es", "pt", "uk", "th", "ar", "id", "vi", "it", "ms", "tr"],
   },
+  customFields: {
+    customMessage: "", // Set any custom message here; leave empty to show the latest version message
+    customLink: "", // Set a custom link here; leave empty to link to the latest release
+  },
 };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,9 +9,12 @@ import Translate from "@docusaurus/Translate";
 import {useWindowSize} from "@docusaurus/theme-common";
 import EditorPreview from "../components/EditorPreview";
 import LanguageIntegration from "../components/LanguageIntegration";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 
 function HomepageHeader() {
-  const [latestVersion, setLatestVersion] = useState("...");
+  const [latestVersion, setLatestVersion] = useState("v3.4.1");
+  const {siteConfig} = useDocusaurusContext();
+  const {customFields} = siteConfig;
 
   useEffect(() => {
     fetch("https://api.github.com/repos/casbin/casbin/releases/latest")
@@ -20,16 +23,17 @@ function HomepageHeader() {
       .catch(() => setLatestVersion("v3.4.1"));
   }, []);
 
-  const pillText = latestVersion === "..." ? "Loading latest release..." : `Casbin ${latestVersion} Released`;
+  const pillText = customFields?.customMessage || `Casbin ${latestVersion} Released`;
+  const link = customFields?.customLink || `https://github.com/casbin/casbin/releases/tag/${latestVersion}`;
 
   return (
     <header className={clsx("hero hero--primary", styles.heroBanner)}>
       <div className="container">
-        <a href="https://github.com/casbin/casbin" className={styles.heroPill} target="_blank" rel="noopener noreferrer" aria-label="Casbin GitHub repository">
+        <Link href={link} target="_blank" rel="noopener noreferrer" className={styles.heroPill}>
           <span className={styles.pillNew}>NEW</span>
           <span className={styles.pillText}>{pillText}</span>
           <span className={styles.pillArrow}>→</span>
-        </a>
+        </Link>
         <h1 className="hero__title">
           <Translate>Open-source authorization for applications</Translate>
         </h1>

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -170,60 +170,35 @@ html[data-theme="light"] .highlightedKeyword {
   font-weight: 600;
   font-size: 1rem;
   backdrop-filter: blur(var(--pill-blur));
-  transition: background-color 0.16s ease;
+  transition: all 0.3s ease;
   position: relative;
   overflow: hidden;
+  z-index: 1;
 }
 
 .heroPill::before {
   content: "";
   position: absolute;
-  left: 50%;
-  bottom: 8px;
-  width: 60%;
-  height: 26px;
-  transform: translateX(-50%) scaleY(1);
-  transform-origin: bottom center;
-
-  /* radial gradient that is wide at bottom and narrows upward */
-  background: var(--pill-glow);
-  border-radius: 999px;
-  filter: blur(var(--pill-blur));
-  transition: opacity 0.22s ease, filter 0.18s ease;
-  opacity: 0.6; /* stronger faint state */
-  z-index: 2;
-  pointer-events: none;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-radius: inherit;
+  padding: 2px; /* Border width */
+  background: linear-gradient(45deg, #7c3aed, #a855f7, #ec4899); /* Purple to pink gradient */
+  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+  mask-composite: xor;
+  clip-path: inset(0 50% 0 50%);
+  transition: clip-path 0.8s ease;
+  z-index: -1;
 }
 
 .heroPill:hover::before {
-  /* no scale change — only deepen */
-  opacity: 0.98;
-  filter: blur(var(--pill-hover-blur));
+  clip-path: inset(0);
 }
 
-.heroPill::after {
-  /* thin full-width base glow along the very bottom */
-  content: "";
-  position: absolute;
-  left: 4%;
-  right: 4%;
-  bottom: 4px;
-  height: 6px;
-  background: var(--pill-after-bg);
-  border-radius: 999px;
-  filter: blur(var(--pill-blur));
-  opacity: 0.55; /* stronger base glow */
-  transition: opacity 0.22s ease, transform 0.22s ease;
-  z-index: 1;
-  pointer-events: none;
-}
-
-.heroPill:hover::after {
-  opacity: 0.95;
-  transform: translateY(-3px);
-}
-
-/* Ensure pill children sit above the glow overlay */
+/* Ensure pill children sit above */
 .heroPill > * {
   position: relative;
   z-index: 3;


### PR DESCRIPTION
Adds a news bar above the main hero title that displays a short news line. This bar fetches the latest Casbin release from GitHub Releases and links to the release page.