### PR TITLE
feat: casbin-forward-auth as cloud native authorization middleware

### DIFF
--- a/docs/CloudNative.mdx
+++ b/docs/CloudNative.mdx
@@ -18,6 +18,7 @@ Project | Author | Description
 [k8s-authz](https://github.com/casbin/k8s-authz) | Casbin | Authorization middleware for [Kubernetes](https://kubernetes.io/)
 [envoy-authz](https://github.com/casbin/envoy-authz) | Casbin | Authorization middleware for [Istio](https://istio.io/) and [Envoy](https://envoyproxy.io/)
 [kubesphere-authz](https://github.com/casbin/kubesphere-authz) | Casbin | Authorization middleware for [kubeSphere](https://kubesphere.io/)
+[casbin-forward-auth](https://github.com/grepplabs/casbin-forward-auth) | grepplabs | Authorization middleware for [Traefik](https://traefik.io/), [NGINX](https://nginx.org/), [HAProxy](https://www.haproxy.com/), [Envoy Gateway](https://gateway.envoyproxy.io/), [Istio](https://istio.io/) and [Envoy](https://www.envoyproxy.io/)
 
 ```mdx-code-block
 </TabItem>


### PR DESCRIPTION
casbin-forward-auth as cloud native authorization middleware for Traefik, NGINX, HAProxy, Envoy Gateway, Istio and Envoy